### PR TITLE
Release 56.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,6 @@ let package = Package(
         .library(name: "AnylinePackage", targets: ["Anyline"]),
     ],
     targets: [
-        .binaryTarget(name: "Anyline", url: "https://mobile-sdk-ios.anyline.io/spm/Anyline.xcframework-spm-56.2.0.zip", checksum: "0d153f3595c466afd7fdf6b1020342cb54c24240b52eddb73de03c9345422e83")
+        .binaryTarget(name: "Anyline", url: "https://mobile-sdk-ios.anyline.io/spm/Anyline.xcframework-spm-56.3.0.zip", checksum: "fd2ad2847801619799c99267f02f4657beab64dc217e56258a0e5038f1ddbd84")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -2,22 +2,42 @@
 
 # Anyline (Swift Package)
 
-This is a repository for the [Anyline SDK for iOS](https://github.com/Anyline/anyline-ocr-examples-ios) Swift Package.
+Swift Package for the [Anyline SDK for iOS](https://documentation.anyline.com/ios-sdk-component/latest/) — scanning and OCR for iOS apps.
 
-### Getting Started
+**Swift Package Manager is the recommended way to add the Anyline iOS SDK to your project.** CocoaPods remains available, but CocoaPods Trunk becomes read-only on 2026-12-02, and no new SDK version can be published there after that date. Already-published versions stay installable indefinitely, so existing CocoaPods projects keep building — migrate to Swift Package Manager to keep receiving SDK updates.
 
-To use, click on File > Swift Packages > Add Package Dependency, and enter https://github.com/Anyline/anyline-ocr-spm-module.git in the search box.
+## Getting Started
 
-If you are a framework author relying on Anyline SDK as a dependency, edit your Package.swift to add the dependency as follows:
+In Xcode, choose **File → Add Package Dependencies…**, enter the package URL, and pick a version:
 
 ```
+https://github.com/Anyline/anyline-ocr-spm-module.git
+```
+
+If you are a framework author depending on the Anyline SDK, add it to your `Package.swift`:
+
+```swift
 dependencies: [
-    .package(url: "https://github.com/Anyline/anyline-ocr-spm-module.git")
+    .package(url: "https://github.com/Anyline/anyline-ocr-spm-module.git", from: "56.3.0")
 ]
 ```
 
-More information can be found [here](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app).
+Each SDK release is published here as a Git tag, so you can pin an exact version or use a range. See Apple's guide to [adding package dependencies](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) for the general workflow.
+
+Full integration instructions, configuration reference and release notes are in the [Anyline iOS SDK documentation](https://documentation.anyline.com/ios-sdk-component/latest/getting-started.html).
+
+## Requirements
+
+A valid Anyline license key is required. See [Getting Started](https://documentation.anyline.com/ios-sdk-component/latest/getting-started.html) for how to obtain and install one.
+
+## Note on Apple Silicon simulators
+
+The current binary ships `ios-arm64` (device) and `ios-x86_64-simulator` slices. On an Apple Silicon Mac, a default simulator build will not find a matching slice. Until a universal simulator slice is published, either run on a physical device or exclude `arm64` for the simulator SDK in your target's build settings:
+
+```
+EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64
+```
 
 ## Get Help
 
-We don't actively monitor the Github Issues. If there is anything you are missing, you require support, or want to provide us with feedback, please reach out to us via https://support.anyline.com, where you either may find helpful information in our Knowledge Base or you can open a Support Ticket for more specific inquiries.
+We don't actively monitor GitHub Issues. If something is missing, you need support, or you'd like to give feedback, please reach out via [support.anyline.com](https://support.anyline.com) — you may find what you need in the Knowledge Base, or you can open a Support Ticket for more specific enquiries.


### PR DESCRIPTION
Updates the binary target to **56.3.0** and replaces the README.

[Release Notes](https://documentation.anyline.com/ios-sdk-component/latest/release-notes.html#56-3-0-2026-08-04)

## Package.swift

Points `binaryTarget` at the 56.3.0 xcframework on the CDN with its SHA-256:

```
url:      https://mobile-sdk-ios.anyline.io/spm/Anyline.xcframework-spm-56.3.0.zip
checksum: fd2ad2847801619799c99267f02f4657beab64dc217e56258a0e5038f1ddbd84
```

The checksum was computed from the zip **as hosted on the CDN**, not from a local build, so it matches exactly what consumers download. Verified three times independently: by `make prepare_spm_release`, by `make verify_spm_release`, and by hashing the CDN copy directly.

## README

Replaced. Four defects in the current text:

1. **CocoaPods position was undocumented.** SPM is now stated as the recommended channel, with the honest current position: CocoaPods remains available, Trunk becomes read-only on 2026-12-02, no new versions can be published there after that date, and already-published versions stay installable indefinitely. Wording matches the 56.3.0 release notes so the two cannot contradict each other.
2. **Stale Xcode menu path.** `File > Swift Packages > Add Package Dependency` has not been the menu for several Xcode versions. Now `File → Add Package Dependencies…`.
3. **`Package.swift` snippet did not resolve.** It was `.package(url:)` with no version requirement, which fails on current tools versions. Now includes `from: "56.3.0"`.
4. **Apple Silicon simulator limitation was undocumented.** The binary ships `ios-arm64` and `ios-x86_64-simulator` only. A default simulator build on Apple Silicon fails with `'Anyline/Anyline.h' file not found`, and the `EXCLUDED_ARCHS` workaround currently exists only inside the wrapper podspecs — direct SPM consumers get no guidance at all today. Remove that section once a universal simulator slice ships.

All five external links verified HTTP 200.

## Not in this PR

`platforms: [.iOS("11")]` understates the requirement — the shipped framework reports `MinimumOSVersion = 12.0` in both slices. Left unchanged here and tracked in MSDK-1583, since it predates this release.